### PR TITLE
require dash in tabnine-bridge

### DIFF
--- a/acm/tabnine-bridge.el
+++ b/acm/tabnine-bridge.el
@@ -51,6 +51,7 @@
 
 (require 'cl-lib)
 (require 'json)
+(require 'dash)
 
 ;;
 ;; Constants


### PR DESCRIPTION
https://github.com/manateelazycat/lsp-bridge/blob/master/acm/tabnine-bridge.el#L257-L263

the dash is needed for the function `--filter` and `--remove` here